### PR TITLE
Fix infinite loop and disable broken crashrecover

### DIFF
--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -110,7 +110,7 @@ include("zombieescape/sv_zombieescape.lua")
 include("server/sv_downloads.lua")
 include("server/sv_redeem.lua")
 include("server/sv_catbomb.lua")
-include("server/sv_crashrecover.lua")
+--include("server/sv_crashrecover.lua")
 include("server/sv_extras.lua")
 
 if file.Exists(GM.FolderName.."/gamemode/misc/maps/"..game.GetMap()..".lua", "LUA") then

--- a/gamemode/server/sv_sigils.lua
+++ b/gamemode/server/sv_sigils.lua
@@ -124,13 +124,17 @@ function GM:SpawnRandomSigilProps(pos)
 		prop:IsInWorld()
 		prop:SetPos(pos)
 		prop:SetVelocity(Vector(0, 0, 0))
-		if prop:IsInWorld() == false then
-			while prop:IsInWorld() == false do
-				pos = pos + randompos[math.random(#randompos)]
-				prop:SetPos(pos)
-			end
+		local iterationLimit = 100
+		while prop:IsInWorld() == false and iterationLimit > 0 do
+			iterationLimit = iterationLimit - 1
+			pos = pos + randompos[math.random(#randompos)]
+			prop:SetPos(pos)
 		end
-		prop:Spawn()
+		if iterationLimit > 0 then
+			prop:Spawn()
+		else
+			prop:Remove()
+		end
 	end
 end
 


### PR DESCRIPTION
- Add limit to sigil prop spawning loop, so it doesn't try to move a prop forever.
- Disable sv_crashrecover.lua, as it overwrites changelevel commands every now and then, even though no crash has occured.